### PR TITLE
Added list functionality to _fit_in function

### DIFF
--- a/SPARQLTransformer.py
+++ b/SPARQLTransformer.py
@@ -268,6 +268,12 @@ def _fit_in(instance, line, options):
                 instance[k] = [instance[k]]
             return
 
+        if isinstance(variable, list):
+            fii_fun = _fit_in(variable, line, options)
+            for i in range(len(variable)):
+                fii_fun(i)
+            return
+
         if not isinstance(variable, str):
             return
 

--- a/SPARQLTransformer.py
+++ b/SPARQLTransformer.py
@@ -272,6 +272,8 @@ def _fit_in(instance, line, options):
             fii_fun = _fit_in(variable, line, options)
             for i in range(len(variable)):
                 fii_fun(i)
+            if all(item is None for item in variable):
+                instance.pop(k)
             return
 
         if not isinstance(variable, str):
@@ -297,7 +299,10 @@ def _fit_in(instance, line, options):
 
         # variable not in result, delete from
         if variable not in line:
-            instance[k] = None
+            if isinstance(instance, list):
+                instance[k] = None
+            else:
+                instance.pop(k)
         else:
             opt = options.copy()
             opt['accept'] = accept

--- a/SPARQLTransformer.py
+++ b/SPARQLTransformer.py
@@ -297,7 +297,7 @@ def _fit_in(instance, line, options):
 
         # variable not in result, delete from
         if variable not in line:
-            instance.pop(k)
+            instance[k] = None
         else:
             opt = options.copy()
             opt['accept'] = accept


### PR DESCRIPTION
I added Python list functionality to a _fit_in function. Previously only going through objects of type dict were allowed, not list.
It allows me to use variables in a list like that:
`"coordinates": ["?lat_n", "?long_n"]`